### PR TITLE
Upgrade Casbin.NET to version 1.13.0 

### DIFF
--- a/Casbin.NET.Watcher.Redis.UnitTests/Casbin.NET.Watcher.Redis.UnitTests.csproj
+++ b/Casbin.NET.Watcher.Redis.UnitTests/Casbin.NET.Watcher.Redis.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/Casbin.NET.Watcher.Redis/Casbin.NET.Watcher.Redis.csproj
+++ b/Casbin.NET.Watcher.Redis/Casbin.NET.Watcher.Redis.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Casbin.NET" Version="1.2.3" />
+    <PackageReference Include="Casbin.NET" Version="1.13.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
   </ItemGroup>
 

--- a/Casbin.NET.Watcher.Redis/RedisWatcher.cs
+++ b/Casbin.NET.Watcher.Redis/RedisWatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NetCasbin.Persist;
 using StackExchange.Redis;
 
@@ -67,11 +68,28 @@ namespace Redis.Casbin.NET
         }
 
         /// <summary>
+        /// Set the callback to trigger when a message is received
+        /// </summary>
+        /// <param name="callback"></param>
+        public void SetUpdateCallback(Func<Task> callback)
+        {
+            this.callback = () => { Task.Run(this.callback); };
+        }
+
+        /// <summary>
         /// Publish a message to prevent other instances
         /// </summary>
         public void Update()
         {
             publisher.PublishAsync(channelName, localID);
+        }
+
+        /// <summary>
+        /// Publish a message to prevent other instances
+        /// </summary>
+        public Task UpdateAsync()
+        {
+            return publisher.PublishAsync(channelName, localID);
         }
 
         /// <summary>


### PR DESCRIPTION
IWatcher interface has been changed since Casbin.NET v 1.2.3
These changes are intended to support new methods in IWatcher